### PR TITLE
Darker Nights and patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -140,71 +140,59 @@ plugins:
   - name: 'DarkerNights-TrueStorms-LITE-Audio.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
     after:
-      # Place DarkerNights-TrueStorms-LITE-Audio.esp after TrueStormsFO4-LITE-Audio.esp
-      # to ensure the magic of Darker Nights is applied to WTHR records modified by the True Storms LITE Audio addon
+      # Ensure the magic of Darker Nights is applied to WTHR records modified by the True Storms LITE Audio addon
       - 'TrueStormsFO4-LITE-Audio.esp'
     msg:
-      # Display a warning when Darker Nights patch for True Storms LITE Audio addon is NOT used along with the True Storms LITE Audio addon
       - type: warn
-        content: 'When plugin ''TrueStormsFO4-LITE-Audio.esp'' is **NOT** active plugin ''DarkerNights-TrueStorms.esp'' should be used instead. TIP: Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms mod installation.'
+        content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
         lang: eng
         condition: 'not(active("TrueStormsFO4-LITE-Audio.esp")) and active("DarkerNights-TrueStorms-LITE-Audio.esp")'
     inc:
-      # Indicate file DarkerNights-TrueStorms-LITE-Audio.esp and DarkerNights-TrueStorms.esp should not be used together
       - 'DarkerNights-TrueStorms.esp'
 
   - name: 'DarkerNights-TrueStorms.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
     msg:
-      # Display a warning when Darker Nights patch for True Storms STANDARD is used along with the True Storms LITE Audio addon
       - type: warn
-        content: 'When plugin ''TrueStormsFO4-LITE-Audio.esp'' is active plugin ''DarkerNights-TrueStorms-LITE-Audio.esp'' should be used instead. TIP: Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms mod installation.'
+        content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
         lang: eng
         condition: 'active("TrueStormsFO4-LITE-Audio.esp") and active("DarkerNights-TrueStorms.esp")'
+    inc:
+      - 'DarkerNights-TrueStorms-LITE-Audio.esp'
 
   - name: 'TrueStormsFO4.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
     after:
-      # Place TrueStormsFO4.esp after DarkerNights.esp
-      # This is the order in which masters appear in the Darker Nights patches
       - 'DarkerNights.esp'
     msg:
-      # Display a message when none of the Darker Nights patches is not used
       - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
         lang: eng
         condition: 'active("TrueStormsFO4.esp") and active("DarkerNights.esp") and not active("DarkerNights-TrueStorms.esp") and not active("DarkerNights-TrueStorms-LITE-Audio.esp")'
 
   - name: 'TrueStormsFO4-LITE-Audio.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
     after:
-      # Place TrueStormsFO4-LITE-Audio.esp after DarkerNights-TrueStorms.esp (in the event they are used together - which is not correct)
-      # to ensure the WTHR record changes brought by the True Storms LITE Audio addon are not overwritten by the Darker Nights patch intended for the STANDARD version of True Storms only
+      # Ensure the WTHR record changes brought by the True Storms LITE Audio addon are not overwritten by the Darker Nights patch which is intended for the STANDARD version of True Storms only
       # Note: Conflicting WTHR records will not be darkened but that is the guaranteed "lesser evil".
       - 'DarkerNights-TrueStorms.esp'
 
   - name: 'FogOut.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/2428' ]
     after:
-      # Place FogOut.esp after DarkerNights.esp
-      # This is the order in which masters appear in the Darker Nights patches
       - 'DarkerNights.esp'
     msg:
-      # Display a message when Darker Nights patch is not used
       - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
         lang: eng
         condition: 'active("FogOut.esp") and active("DarkerNights.esp") and not active("DarkerNights-FogOut.esp")'
 
   - name: 'Radiant Clouds and Fogs.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/735' ]
     after:
-      # Place 'Radiant Clouds and Fogs.esp' after DarkerNights.esp
-      # This is the order in which masters appear in the Darker Nights patches
       - 'DarkerNights.esp'
     msg:
-      # Display a message when Darker Nights patch is not used
       - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
         lang: eng
         condition: 'active("Radiant Clouds and Fogs.esp") and active("DarkerNights.esp") and not active("DarkerNights-Radiant.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19,6 +19,12 @@ common:
       - lang: zh_CN
         str: '只使用一个%1%。'
 
+  - &patchAvailable
+    type: say
+    content:
+      - lang: en
+        str: 'This plugin conflicts with plugin "%1%", however a patch is available.'
+
 globals:
   - type: say
     content:
@@ -145,7 +151,7 @@ plugins:
     msg:
       - type: warn
         content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
-        lang: eng
+        lang: en
         condition: 'not(active("TrueStormsFO4-LITE-Audio.esp")) and active("DarkerNights-TrueStorms-LITE-Audio.esp")'
     inc:
       - 'DarkerNights-TrueStorms.esp'
@@ -155,7 +161,7 @@ plugins:
     msg:
       - type: warn
         content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
-        lang: eng
+        lang: en
         condition: 'active("TrueStormsFO4-LITE-Audio.esp") and active("DarkerNights-TrueStorms.esp")'
     inc:
       - 'DarkerNights-TrueStorms-LITE-Audio.esp'
@@ -165,9 +171,8 @@ plugins:
     after:
       - 'DarkerNights.esp'
     msg:
-      - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
-        lang: eng
+      - <<: *patchAvailable
+        subs: [ 'DarkerNights.esp' ]
         condition: 'active("TrueStormsFO4.esp") and active("DarkerNights.esp") and not active("DarkerNights-TrueStorms.esp") and not active("DarkerNights-TrueStorms-LITE-Audio.esp")'
 
   - name: 'TrueStormsFO4-LITE-Audio.esp'
@@ -182,9 +187,8 @@ plugins:
     after:
       - 'DarkerNights.esp'
     msg:
-      - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
-        lang: eng
+      - <<: *patchAvailable
+        subs: [ 'DarkerNights.esp' ]
         condition: 'active("FogOut.esp") and active("DarkerNights.esp") and not active("DarkerNights-FogOut.esp")'
 
   - name: 'Radiant Clouds and Fogs.esp'
@@ -192,7 +196,6 @@ plugins:
     after:
       - 'DarkerNights.esp'
     msg:
-      - type: say
-        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. Install and activate the appropriate Darker Nights patch.'
-        lang: eng
+      - <<: *patchAvailable
+        subs: [ 'DarkerNights.esp' ]
         condition: 'active("Radiant Clouds and Fogs.esp") and active("DarkerNights.esp") and not active("DarkerNights-Radiant.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -136,3 +136,75 @@ plugins:
     url: [ 'http://www.nexusmods.com/fallout4/mods/2142' ]
     after:
       - 'Simple Bug Fixes.esp'
+
+  - name: 'DarkerNights-TrueStorms-LITE-Audio.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
+    after:
+      # Place DarkerNights-TrueStorms-LITE-Audio.esp after TrueStormsFO4-LITE-Audio.esp
+      # to ensure the magic of Darker Nights is applied to WTHR records modified by the True Storms LITE Audio addon
+      - 'TrueStormsFO4-LITE-Audio.esp'
+    msg:
+      # Display a warning when Darker Nights patch for True Storms LITE Audio addon is NOT used along with the True Storms LITE Audio addon
+      - type: warn
+        content: 'When plugin ''TrueStormsFO4-LITE-Audio.esp'' is **NOT** active plugin ''DarkerNights-TrueStorms.esp'' should be used instead. TIP: Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms mod installation.'
+        lang: eng
+        condition: 'not(active("TrueStormsFO4-LITE-Audio.esp")) and active("DarkerNights-TrueStorms-LITE-Audio.esp")'
+    inc:
+      # Indicate file DarkerNights-TrueStorms-LITE-Audio.esp and DarkerNights-TrueStorms.esp should not be used together
+      - 'DarkerNights-TrueStorms.esp'
+
+  - name: 'DarkerNights-TrueStorms.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
+    msg:
+      # Display a warning when Darker Nights patch for True Storms STANDARD is used along with the True Storms LITE Audio addon
+      - type: warn
+        content: 'When plugin ''TrueStormsFO4-LITE-Audio.esp'' is active plugin ''DarkerNights-TrueStorms-LITE-Audio.esp'' should be used instead. TIP: Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms mod installation.'
+        lang: eng
+        condition: 'active("TrueStormsFO4-LITE-Audio.esp") and active("DarkerNights-TrueStorms.esp")'
+
+  - name: 'TrueStormsFO4.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
+    after:
+      # Place TrueStormsFO4.esp after DarkerNights.esp
+      # This is the order in which masters appear in the Darker Nights patches
+      - 'DarkerNights.esp'
+    msg:
+      # Display a message when none of the Darker Nights patches is not used
+      - type: say
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        lang: eng
+        condition: 'active("TrueStormsFO4.esp") and active("DarkerNights.esp") and not active("DarkerNights-TrueStorms.esp") and not active("DarkerNights-TrueStorms-LITE-Audio.esp")'
+
+  - name: 'TrueStormsFO4-LITE-Audio.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
+    after:
+      # Place TrueStormsFO4-LITE-Audio.esp after DarkerNights-TrueStorms.esp (in the event they are used together - which is not correct)
+      # to ensure the WTHR record changes brought by the True Storms LITE Audio addon are not overwritten by the Darker Nights patch intended for the STANDARD version of True Storms only
+      # Note: Conflicting WTHR records will not be darkened but that is the guaranteed "lesser evil".
+      - 'DarkerNights-TrueStorms.esp'
+
+  - name: 'FogOut.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/2428' ]
+    after:
+      # Place FogOut.esp after DarkerNights.esp
+      # This is the order in which masters appear in the Darker Nights patches
+      - 'DarkerNights.esp'
+    msg:
+      # Display a message when Darker Nights patch is not used
+      - type: say
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        lang: eng
+        condition: 'active("FogOut.esp") and active("DarkerNights.esp") and not active("DarkerNights-FogOut.esp")'
+
+  - name: 'Radiant Clouds and Fogs.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/735' ]
+    after:
+      # Place 'Radiant Clouds and Fogs.esp' after DarkerNights.esp
+      # This is the order in which masters appear in the Darker Nights patches
+      - 'DarkerNights.esp'
+    msg:
+      # Display a message when Darker Nights patch is not used
+      - type: say
+        content: 'This plugin conflicts with plugin ''DarkerNights.esp''. TIP: Install and activate the appropriate Darker Nights patch.'
+        lang: eng
+        condition: 'active("Radiant Clouds and Fogs.esp") and active("DarkerNights.esp") and not active("DarkerNights-Radiant.esp")'


### PR DESCRIPTION
Provides load order optimization for Darker Nights and all its patches and covers upcoming True Storm 1.3 plugins and the respective patches, however works with the existing versions as well.

Tested locally with the NexusMods release of LOOT 0.8.1.53 at .

Note there are 5 messages to translate (3 of which are the same), with the following entries: 
DarkerNights-TrueStorms-LITE-Audio.esp
DarkerNights-TrueStorms.esp
FogOut.esp
TrueStormsFO4.esp
Radiant Clouds and Fogs.esp
