### PR TITLE
Load "Alternate Start - Infinite Answer" last

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -629,6 +629,9 @@ plugins:
     url: [ 'http://www.nexusmods.com/fallout4/mods/10193' ]
     inc: [ 'Concentrated Splitter.esp' ]
     req: [ 'Lasers Have No Recoil.esp' ]
+  - name: 'OSM_AlternateStart_Protocol-InfiniteAnswer.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/13762' ]
+    priority: 1999000
 
   - name: 'OCDWorkshopDLCPatch.esp'
     msg:


### PR DESCRIPTION
According to the mod's [Nexus page](http://www.nexusmods.com/fallout4/mods/13762), it should be loaded at the bottom of the list. This sets a high priority for that mod to get it to go last in the list by default.
