### PR TITLE
Add "Vault-Tec Historical Preservation Initiative"

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -632,6 +632,9 @@ plugins:
   - name: 'OSM_AlternateStart_Protocol-InfiniteAnswer.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/13762' ]
     priority: 1999000
+  - name: 'Vault-Tec Historical Preservation Initiative.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/12019' ]
+    priority: -1900000
 
   - name: 'OCDWorkshopDLCPatch.esp'
     msg:


### PR DESCRIPTION
This mod is meant to be a "lore patch" that fixes some of the plot holes in F4's storylines. It makes sense for it to load just past the unofficial patches (-1900000 versus -1999000).
