### PR TITLE
Darker Nights v1.11 update

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -548,57 +548,21 @@ plugins:
     inc:
       - 'ShaikujinSettlementAttacked.esp'
       - 'ShaikujinSettlementAttacked_NoInfo.esp'
-  - name: 'DarkerNights-TrueStorms-LITE-Audio.esp'
+  - name: 'DarkerNights.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
     after:
-      # Ensure the magic of Darker Nights is applied to WTHR records modified by the True Storms LITE Audio addon
+      # Patches provided for plugins below
+      - 'FogOut.esp'
+      - 'Nuclear weather.esp'
+      - 'Radiant Clouds and Fogs.esp'
+      - 'TrueStormsFO4.esp'
       - 'TrueStormsFO4-LITE-Audio.esp'
+      - 'TrueStormsFO4.esm'
+      - 'TrueStormsFO4-FarHarbor.esp'
+      - 'Vivid Weathers - FO4.esp'
     msg:
-      - type: warn
-        content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
-        lang: en
-        condition: 'not(active("TrueStormsFO4-LITE-Audio.esp")) and active("DarkerNights-TrueStorms-LITE-Audio.esp")'
-    inc:
-      - 'DarkerNights-TrueStorms.esp'
-  - name: 'DarkerNights-TrueStorms.esp'
-    url: [ 'http://www.nexusmods.com/fallout4/mods/191' ]
-    msg:
-      - type: warn
-        content: 'This plugin does not match the active True Storms plugins. Reinstall the **Darker Nights for True Storms** patch and select the option which matches your True Storms installation.'
-        lang: en
-        condition: 'active("TrueStormsFO4-LITE-Audio.esp") and active("DarkerNights-TrueStorms.esp")'
-    inc:
-      - 'DarkerNights-TrueStorms-LITE-Audio.esp'
-  - name: 'TrueStormsFO4.esp'
-    url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
-    after:
-      - 'DarkerNights.esp'
-    msg:
-      - <<: *patchAvailable
-        subs: [ 'DarkerNights.esp' ]
-        condition: 'active("TrueStormsFO4.esp") and active("DarkerNights.esp") and not active("DarkerNights-TrueStorms.esp") and not active("DarkerNights-TrueStorms-LITE-Audio.esp")'
-  - name: 'TrueStormsFO4-LITE-Audio.esp'
-    url: [ 'http://www.nexusmods.com/fallout4/mods/4472' ]
-    after:
-      # Ensure the WTHR record changes brought by the True Storms LITE Audio addon are not overwritten by the Darker Nights patch which is intended for the STANDARD version of True Storms only
-      # Note: Conflicting WTHR records will not be darkened but that is the guaranteed "lesser evil".
-      - 'DarkerNights-TrueStorms.esp'
-  - name: 'FogOut.esp'
-    url: [ 'http://www.nexusmods.com/fallout4/mods/2428' ]
-    after:
-      - 'DarkerNights.esp'
-    msg:
-      - <<: *patchAvailable
-        subs: [ 'DarkerNights.esp' ]
-        condition: 'active("FogOut.esp") and active("DarkerNights.esp") and not active("DarkerNights-FogOut.esp")'
-  - name: 'Radiant Clouds and Fogs.esp'
-    url: [ 'http://www.nexusmods.com/fallout4/mods/735' ]
-    after:
-      - 'DarkerNights.esp'
-    msg:
-      - <<: *patchAvailable
-        subs: [ 'DarkerNights.esp' ]
-        condition: 'active("Radiant Clouds and Fogs.esp") and active("DarkerNights.esp") and not active("DarkerNights-Radiant.esp")'
+      - <<: *obsolete
+        condition: 'version("DarkerNights.esp", "1.11", <)'
   - name: 'Scrap Everything.esp'
     msg: [ *doNotClean ]
     url: [ 'http://www.nexusmods.com/fallout4/mods/5320' ]


### PR DESCRIPTION
As discussed #18 I removed previous ordering scheme and added new simple one. Now DrakerNights.esp should sort after any plugins for which a patch is provided. This change was necessary as Darker Nights begins to merge some patches into the main plugin and as the patched plugins become ESM (True Storms 1.4).
