### PR TITLE
Vivid Waters and WET compatibility

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1378,3 +1378,9 @@ plugins:
       - <<: *SmashedVsBashedPatch
         condition: 'file("Smashed Patch.esp")'
         subs: [ 'Smashed Patch.esp' ]
+  - name: 'Vivid Waters.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/16425' ]
+    after:
+      - 'WET.esp'
+      - 'WET Murkier.esp'
+      - 'WET Clearer.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -905,10 +905,13 @@ plugins:
         subs: [ 'ArmorKeywords.esm' ]
   - name: 'WET Clearer.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/244' ]
-    inc: [ 'WET Murkier.esp' ]
+    inc: [ 'WET Murkier.esp' , 'WET.esp' ]
   - name: 'WET Murkier.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/244' ]
-    inc: [ 'WET Clearer.esp' ]
+    inc: [ 'WET Clearer.esp', 'WET.esp' ]
+  - name: 'WET.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/244' ]
+    inc: [ 'WET Clearer.esp', 'WET Murkier.esp' ]
   - name: 'Lasers Have No Recoil.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/9417/' ]
     inc: [ 'Concentrated Splitter.esp' ]


### PR DESCRIPTION
See [Vivid Waters Mod Page](http://www.nexusmods.com/fallout4/mods/16425) for compatibility information.

I've verified that LOOT properly orders VW after WET.