### PR TITLE
Update Sim Settlements' plugin patch condition with Valdacil's Item Sorting

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1582,8 +1582,8 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - "Valdacil's Item Sorting"
-          - '[SimSettlements_VIS.esp](http://www.nexusmods.com/fallout4/mods/21872)'
-        condition: 'active("ValdacilsItemSorting-.+\.esp") and not active("SimSettlements_VIS.esp")'
+          - '[SimSettlements_VIS.esp](https://drive.google.com/file/d/0B0Ul1EMQefa_TjZXOWtRSXhmXzg/view?usp=sharing)'
+        condition: 'version("SimSettlements.esm", "2.0", <) and active("ValdacilsItemSorting-.+\.esp") and not active("SimSettlements_VIS.esp")'
   - name: 'llamaCompanionHeather.esp'
     url: [ 'http://www.nexusmods.com/fallout4/mods/23273' ]
     msg:


### PR DESCRIPTION
Checks if Sim Settlements is using an older version than 2.0, since according to [this forum post](https://forums.nexusmods.com/index.php?/topic/3482685-valdacils-item-sorting/?p=51475507), the VIS compatibility patch contents have been merged with Sim Settlements' main file as of v2.0.

Plus, since the link for `SimSettlements.esm` does not help at all, I took the liberty to link to a google drive file that was shared for those who still needed the patch. The link was found [right above the reply for the previously-linked post.](https://forums.nexusmods.com/index.php?/topic/3482685-valdacils-item-sorting/?p=51461657)