### PR TITLE
Add error msg for outdated Survival Options/Give Me That Bottle patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1786,3 +1786,9 @@ plugins:
         crc: 0x31827654
         # FO4Edit 3.2
         itm: 4
+  - name: 'SurvivalOptions_GiveMeThatBottlePatch.esp'
+    url: [ 'http://www.nexusmods.com/fallout4/mods/14650' ]
+    msg:
+      - type: error
+        content: "This patch is for an older version of Give Me That Bottle and is not fully compatible with the newest versions of that mod. You may want to update the patch yourself or replace the patch with an automated one by Wrye Bash, Mator Smash, or FO4Edit."
+        condition: 'checksum("SurvivalOptions_GiveMeThatBottlePatch.esp", 42D99A6E)'


### PR DESCRIPTION
I'm not sure whether the `msg` is good or whether I should also do an `active()` check on the plugin. I would appreciate some feedback on this before pushing it into the main branch.