### PR TITLE
Add warning for LOOT <0.13.1 with Creation Club plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -197,6 +197,13 @@ common:
     info: 'A cleaning guide is available [here](https://www.creationkit.com/index.php?title=TES5Edit_Cleaning_Guide_-_TES5Edit).'
 
 globals:
+  - type: warn
+    content:
+      - lang: en
+        text: 'This version of LOOT has inferior handling of Creation Club plugins. Support for these are therefore limited in versions prior to LOOT 0.13.1. It is recommended to update as soon as possible.'
+      - lang: da
+        text: 'Denne version af LOOT har begrænset understøttelse af Creation Club-plugins. Det er derfor anbefalet at opdatere til LOOT 0.13.1 eller senere hurtigst muligt.'
+    condition: 'version("LOOT", "0.13.1.0", <) and file("cc[A-Z]{3}FO4[0-9]{3}-[a-zA-Z0-9()]+\.es(l|m)")'
   - type: say
     content:
       - lang: en


### PR DESCRIPTION
Adds a new `globals` message which warns LOOT <0.13.1 users that have any Creation Club plugins that they ought to update ASAP.

Please don't merge but just give feedback. I'll merge myself. :)

Follow-up to https://github.com/loot/fallout4/pull/73