### PR TITLE
Added conflict resolution information for 'BTInt_Optimization.esp'

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4418,6 +4418,9 @@ plugins:
       - 'Farm_DLCCoast.esp'
       - 'Farm_DLCNukaWorld.esp'
       - 'Farm_DLCworkshop03.esp'
+      - 'OutcastsAndRemnants.esp'
+      - 'Depravity.esp'
+      - 'Z_Horizon_Patch_BTInteriors.esp'
     clean:
       # Version 3.2.1
       - crc: 0x9EADC975


### PR DESCRIPTION
Notably, the previs data will be broken by Depravity, Outcasts and Remnants, and 'Z_Horizon_Patch_BTInteriors.esp'. I recommend loading BTInt_Optimization after all of them or disable previs data in the affected area. 