### PR TITLE
Drop NoMerge tags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4883,14 +4883,10 @@ plugins:
 
   - name: 'FO4Merged.esp'
     group: *dynamicPatchesGroup
-    tag:
-      - NoMerge
   - name: 'Smashed Patch.esp'
     group: *dynamicPatchesGroup
     after:
       - 'FO4Merged.esp'
-    tag:
-      - NoMerge
     msg:
       - <<: *onlyUseSmashOrBash
         condition: 'file("Bashed Patch.*\.esp")'


### PR DESCRIPTION
Wrye Bash doesn't merge FO4 plugins anymore since 307.