### PR TITLE
Change message type of &patch3rdParty, &patchIncluded, &patchProvided and &useOnlyOneX

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -244,7 +244,7 @@ common:
         text: 'Kan användas med %1% men skulle kräva extra arbete. En Smashed Patch eller Bash Patch borde användas en ensamstående från varandra.'
 
   - &patch3rdParty
-    type: warn
+    type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A third party patch is available here: %2%'
@@ -265,7 +265,7 @@ common:
       - lang: sv
         text: 'Det verkar som att du använder **%1%**, men du har inte aktiverat en kompabilitetspatch för denna mod. En patch från en tredje part finns här: %2%.'
   - &patchIncluded
-    type: warn
+    type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A compatibility patch is included with this plugin''s installer.'
@@ -286,7 +286,7 @@ common:
       - lang: sv
         text: 'Det verkar som att du använder **%1%**, men du har inte aktiverat en kompabilitetspatch för denna mod. En kompabilitetspatch är inkluderad i denna plugins installationsprogram.'
   - &patchProvided
-    type: warn
+    type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A compatibility patch is provided on this plugin''s mod page.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -380,7 +380,7 @@ common:
         text: '%1% är inte helt kompatibel med denna mod. %2%'
 
   - &useOnlyOneX
-    type: warn
+    type: error
     content:
       - lang: en
         text: 'Use only one %1%.'


### PR DESCRIPTION
`&patch3rdParty`, `&patchIncluded` and `&patchProvided`:
For SLE, SSE, Oblivion, FO3 and FNV the type of these three messages is set to `say`, not `warn`.

As such, change it for Fallout 4 to `say` as well.

`Use only one %1%.`
For SLE, SSE, Oblivion, FO3 and FNV the type of `&useOnlyOneX` is set to `error`, not `warn`.

As such, change it for Fallout 4 to `error` as well.