### PR TITLE
Streamline original en &alsoUseX message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -87,7 +87,7 @@ common:
     type: say
     content:
       - lang: en
-        text: 'It is highly recommended that you also use %1%.'
+        text: 'It''s highly recommended that you also use %1%.'
       - lang: de
         text: 'Es wird dringend empfohlen, dass Sie auch %1% benutzen.'
       - lang: ja


### PR DESCRIPTION
With this PR all en `&alsoUseX` messages across the different masterlists are the same.