### PR TITLE
Add group for Resources & Frameworks

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1141,6 +1141,7 @@ groups:
     after: [ *texturesGroup ]
 
   - name: &frameworksGroup Resources & Frameworks
+    description: 'A group for mods that provide resources and/or a framework for other mods to use.'
     after: [ *fixesGroup ]
 
   - name: &retconGroup Vault-Tec Historical Preservation Initiative

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1140,8 +1140,11 @@ groups:
   - name: &fixesGroup Fixes
     after: [ *texturesGroup ]
 
-  - name: &retconGroup Vault-Tec Historical Preservation Initiative
+  - name: &frameworksGroup Resources & Frameworks
     after: [ *fixesGroup ]
+
+  - name: &retconGroup Vault-Tec Historical Preservation Initiative
+    after: [ *frameworksGroup ]
 
   - name: &underridesGroup Underrides
     after: [ *retconGroup ]


### PR DESCRIPTION
Will be used for framework mods like [AWKCR](https://www.nexusmods.com/fallout4/mods/6091/), [Workshop Framework](https://www.nexusmods.com/fallout4/mods/35004), which are typically placed early in ESM files.