### PR TITLE
Add (SS2) Sim Settlements 2 - Horizon Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3776,17 +3776,6 @@ plugins:
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Scrappers.esp")'
 
-  - name: 'SS2_FDK_TinyLiving.esp'
-    url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/49424/'
-        name: 'Sim Settlements 2 - Tiny Living'
-    msg:
-      - <<: *patch3rdParty
-        subs:
-          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
-        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_TinyLiving.esp")'
-
   - name: 'SS2AOP_VaultTecTools.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48700/'
@@ -3797,6 +3786,17 @@ plugins:
           - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_VaultTechTools.esp")'
+
+  - name: 'SS2_FDK_TinyLiving.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/49424/'
+        name: 'Sim Settlements 2 - Tiny Living'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_TinyLiving.esp")'
 
   - name: 'SS2-Jampads2.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3779,7 +3779,7 @@ plugins:
   - name: 'SS2_FDK_TinyLiving.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/49424/'
-        name: 'im Settlements 2 - Tiny Living'
+        name: 'Sim Settlements 2 - Tiny Living'
     msg:
       - <<: *patch3rdParty
         subs:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3765,16 +3765,16 @@ plugins:
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("SS_Addon_Horizon.esp")'
 
-  - name: 'SS2-Jampads2.esp'
+  - name: 'ohSIM_Sim2_Settlements_Scrappers_Addon.esp'
     url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/48618/'
-        name: 'Jampads 2 - a Sim Settlements 2 Add-on'
+      - link: 'https://www.nexusmods.com/fallout4/mods/48846/'
+        name: 'Sim Settlements 2 Scrappers'
     msg:
       - <<: *patch3rdParty
         subs:
           - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
-        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Jampads2.esp")'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Scrappers.esp")'
 
   - name: 'SS2_FDK_TinyLiving.esp'
     url:
@@ -3787,17 +3787,6 @@ plugins:
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_TinyLiving.esp")'
 
-  - name: 'ohSIM_Sim2_Settlements_Scrappers_Addon.esp'
-    url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/48846/'
-        name: 'Sim Settlements 2 Scrappers'
-    msg:
-      - <<: *patch3rdParty
-        subs:
-          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
-        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Scrappers.esp")'
-
   - name: 'SS2AOP_VaultTecTools.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48700/'
@@ -3808,6 +3797,17 @@ plugins:
           - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_VaultTechTools.esp")'
+
+  - name: 'SS2-Jampads2.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/48618/'
+        name: 'Jampads 2 - a Sim Settlements 2 Add-on'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Jampads2.esp")'
 
   - name: 'SS2WastelandVenturers.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3772,9 +3772,10 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_Jampads2.esp")'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Jampads2.esp")'
+
   - name: 'SS2_FDK_TinyLiving.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/49424/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3794,9 +3794,10 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_Scrappers.esp")'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_Scrappers.esp")'
+
   - name: 'SS2AOP_VaultTecTools.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48700/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3805,9 +3805,10 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_VaultTechTools.esp")'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_VaultTechTools.esp")'
+
   - name: 'SS2WastelandVenturers.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48060/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3783,9 +3783,10 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_TinyLiving.esp")'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_TinyLiving.esp")'
+
   - name: 'ohSIM_Sim2_Settlements_Scrappers_Addon.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48846/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3816,9 +3816,9 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_WastelandVenturers.esp")'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
+        condition: 'active("Z_Horizon.esp") and not active("Z_Horizon_SS2_WastelandVenturers.esp")'
 
 ###### Anything new can go after this (if you're not sure where to put it) ######
   # Radrose Usability Enhancements

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3761,8 +3761,8 @@ plugins:
         condition: 'active("XDI.esm") and not active("SS2_XDI Patch.esp") and not active("SS2_XDI Patch-Basic.esp") and not active("SS2_XDI Patch-Basic_esl.esp")'
       - <<: *patch3rdParty
         subs:
-          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
-          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+          - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon\.es(m|p)") and not active("SS_Addon_Horizon.esp")'
   - name: 'SS2-Jampads2.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3764,6 +3764,7 @@ plugins:
           - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
         condition: 'active("Z_Horizon.esp") and not active("SS_Addon_Horizon.esp")'
+
   - name: 'SS2-Jampads2.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48618/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3759,6 +3759,61 @@ plugins:
           - '[Extended Dialogue Interface](https://www.nexusmods.com/fallout4/mods/27216)'
           - '[SS2 - XDI Compatibility Patch](https://www.nexusmods.com/fallout4/mods/48254)'
         condition: 'active("XDI.esm") and not active("SS2_XDI Patch.esp") and not active("SS2_XDI Patch-Basic.esp") and not active("SS2_XDI Patch-Basic_esl.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("SS_Addon_Horizon.esp")'
+  - name: 'SS2-Jampads2.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/48618/'
+        name: 'Jampads 2 - a Sim Settlements 2 Add-on'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_Jampads2.esp")'
+  - name: 'SS2_FDK_TinyLiving.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/49424/'
+        name: 'im Settlements 2 - Tiny Living'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_TinyLiving.esp")'
+  - name: 'ohSIM_Sim2_Settlements_Scrappers_Addon.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/48846/'
+        name: 'Sim Settlements 2 Scrappers'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_Scrappers.esp")'
+  - name: 'SS2AOP_VaultTecTools.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/48700/'
+        name: 'Vault-Tec Tools - Sim Settlements 2 Addon Pack'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_VaultTechTools.esp")'
+  - name: 'SS2WastelandVenturers.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/48060/'
+        name: 'Wasteland Venturers Sim Settlements 2 Addon Pack'
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - '[Horizon V1.8](https://www.nexusmods.com/fallout4/mods/17374)'
+          - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186)'
+        condition: 'active("Z_Horizon\.es(m|p)") and not active("Z_Horizon_SS2_WastelandVenturers.esp")'
 
 ###### Anything new can go after this (if you're not sure where to put it) ######
   # Radrose Usability Enhancements

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3763,7 +3763,7 @@ plugins:
         subs:
           - '[Horizon](https://www.nexusmods.com/fallout4/mods/17374/)'
           - '[Sim Settlements 2 - Horizon Patch](https://www.nexusmods.com/fallout4/mods/54186/)'
-        condition: 'active("Z_Horizon\.es(m|p)") and not active("SS_Addon_Horizon.esp")'
+        condition: 'active("Z_Horizon.esp") and not active("SS_Addon_Horizon.esp")'
   - name: 'SS2-Jampads2.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48618/'


### PR DESCRIPTION
1. Add Horizon patch for SS2 core
2. Add Horizon patch for SS2 Jampads
3. Add Horizon patch for SS2 Tiny Living
4. Add Horizon patch for SS2 Scrappers
5. Add Horizon patch for SS2 Vault-Tec Tools
6. Add Horizon patch for SS2 wasteland Venturers

See https://wiki.simsettlements2.com/en/getting-started/known-issues#horizon-patch-required for details.