### PR TITLE
Add Swinging Animated Meat Bags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7081,3 +7081,13 @@ plugins:
         crc: 0x82C7B038
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 1
+
+  - name: 'Swinging Meat Bags.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/users/3463396/'
+        name: 'Swinging Animated Meat Bags'
+    dirty:
+      - <<: *quickClean
+        crc: 0x70647AA7
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        udr: 1


### PR DESCRIPTION
Swinging Animated Meat Bags v1.4.1
Mod was removed from Nexus Mods, currently only available via direct DropBox link on the author's Nexus profile, so opted to link the profile page.