### PR TITLE
Add Flowing Rivers - Better Coastal Waves got an update

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7106,8 +7106,16 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/58035/'
         name: 'Flowing Rivers - Better Coastal Waves got an update'
+      - link: 'https://www.nexusmods.com/fallout4/mods/47153/'
+        name: 'Better Coastal Waves - Wilder Water'
     dirty:
+      # Flowing Rivers
       - <<: *quickClean
         crc: 0x4706BF27
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 21
+      # Better Coastal Waves
+      - <<: *quickClean
+        crc: 0xDDA9F5D3
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 18

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7119,3 +7119,13 @@ plugins:
         crc: 0xDDA9F5D3
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 18
+
+  - name: 'BetterCoastalWaves.esl'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/47153/'
+        name: 'Better Coastal Waves - Wilder Water'
+    dirty:
+      - <<: *quickClean
+        crc: 0x41510FF3
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 18

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7101,3 +7101,13 @@ plugins:
         crc: 0x4F0BB9FE
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 2
+
+  - name: 'BetterCoastalWaves.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/58035/'
+        name: 'Flowing Rivers - Better Coastal Waves got an update'
+    dirty:
+      - <<: *quickClean
+        crc: 0x4706BF27
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 21

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7129,7 +7129,6 @@ plugins:
         crc: 0xDDA9F5D3
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 18
-
   - name: 'BetterCoastalWaves.esl'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/47153/'


### PR DESCRIPTION
Also included Better Coastal Waves (v1.2) as it's an earlier version of Flowing Rivers and they share plugin names.