### PR TITLE
Update Pip-Boy Flashlight

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2315,6 +2315,7 @@ plugins:
       - 'Clarity.esp'
       - 'EnhancedLightsandFX.esp'
       - 'FROST.esp'
+      - 'GT_pipboy.esp'
     msg:
       - <<: *patch3rdParty
         subs:


### PR DESCRIPTION
https://www.nexusmods.com/fallout4/mods/62921?tab=posts

"If you are using Pip-Boy Flashlight with the Galac-Tac Pipboy, you will need to load it after GT_pipboy.esp - otherwise your Pip-Boy flashlight and any flashlight attachments on your weapons, will not work."