### PR TITLE
Add Better Landscape Grass

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2094,7 +2094,7 @@ plugins:
         crc: 0x7E2E53AF
         util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
         itm: 191
-        
+
   - name: 'CliffsEdgeHotelWindowFix.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48887/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2085,7 +2085,9 @@ plugins:
       - *alreadyInOrFixedByPRPv0_59
 
   - name: 'Better Landscape Grass.esp'
-    url: ["https://www.nexusmods.com/fallout4/mods/38360/" ]
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/38360/'
+        name: 'Better Landscape Grass'
     group: *lowPriorityGroup
     dirty:
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2084,6 +2084,15 @@ plugins:
       - *alreadyInOrFixedByFCF
       - *alreadyInOrFixedByPRPv0_59
 
+  - name: 'Better Landscape Grass.esp'
+    url: ["https://www.nexusmods.com/fallout4/mods/38360/" ]
+    group: *lowPriorityGroup
+    dirty:
+      - <<: *quickClean
+        crc: 0x7E2E53AF
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 191
+        
   - name: 'CliffsEdgeHotelWindowFix.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/48887/'


### PR DESCRIPTION
* Add plugin
  * To 'AudioVisual - Fixes' section.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/38360/](https://www.nexusmods.com/fallout4/mods/38360/)

* Assign 'Low Priority Overrides' group
  * Modifies grass and landscape records. Load before mods that have precombine data and after mods that do not have precombine data.

* Add cleaning data