### PR TITLE
Add MrTroubleMaker Fixes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1769,7 +1769,7 @@ plugins:
       - *alreadyInOrFixedByFCF
       - *alreadyInOrFixedByPRPv0_59
 
-  - name: '(MTM-NukaTownEastArchwayFix|MTM-GardenTerraceCeilingFixedByMonorail)\.es[lp]'
+  - name: 'MTM-(NukaTownEastArchwayFix|GardenTerraceCeilingFixedByMonorail)\.es[lp]'
     url: 
       - link: 'https://www.nexusmods.com/fallout4/mods/40513/'
         name: 'Nuka-World - Fixes the East Entrance to Nuka-Town USA near Fizztop Mountain'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1769,6 +1769,14 @@ plugins:
       - *alreadyInOrFixedByFCF
       - *alreadyInOrFixedByPRPv0_59
 
+  - name: '(MTM-NukaTownEastArchwayFix|MTM-GardenTerraceCeilingFixedByMonorail)\.es[lp]'
+    url: [ 'https://www.nexusmods.com/fallout4/mods/40513/' ]
+    group: *fixesGroup
+
+  - name: '(MTM-SlocumJoeCorporateHQReceptionCeilingFixed|MTM-FensParkviewApartmentWallFixed)\.es[lp]'
+    url: [ 'https://www.nexusmods.com/fallout4/mods/40553/' ]
+    group: *fixesGroup
+
   - name: 'Perk Magazine Material Fix.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/6906/' ]
     group: *fixesGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1780,7 +1780,7 @@ plugins:
         subs: [ 'Previsibines Repair Pack' ]
         condition: 'active("PPF.esm")'
 
-  - name: '(MTM-SlocumJoeCorporateHQReceptionCeilingFixed|MTM-FensParkviewApartmentWallFixed)\.es[lp]'
+  - name: 'MTM-(SlocumJoeCorporateHQReceptionCeiling|FensParkviewApartmentWall)Fixed\.es[lp]'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/40553/'
         name: 'Slocum Joe Corporate HQ Reception Ceiling Fixed'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1770,7 +1770,7 @@ plugins:
       - *alreadyInOrFixedByPRPv0_59
 
   - name: 'MTM-(NukaTownEastArchwayFix|GardenTerraceCeilingFixedByMonorail)\.es[lp]'
-    url: 
+    url:
       - link: 'https://www.nexusmods.com/fallout4/mods/40513/'
         name: 'Nuka-World - Fixes the East Entrance to Nuka-Town USA near Fizztop Mountain'
     group: *fixesGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1770,11 +1770,15 @@ plugins:
       - *alreadyInOrFixedByPRPv0_59
 
   - name: '(MTM-NukaTownEastArchwayFix|MTM-GardenTerraceCeilingFixedByMonorail)\.es[lp]'
-    url: [ 'https://www.nexusmods.com/fallout4/mods/40513/' ]
+    url: 
+      - link: 'https://www.nexusmods.com/fallout4/mods/40513/'
+        name: 'Nuka-World - Fixes the East Entrance to Nuka-Town USA near Fizztop Mountain'
     group: *fixesGroup
 
   - name: '(MTM-SlocumJoeCorporateHQReceptionCeilingFixed|MTM-FensParkviewApartmentWallFixed)\.es[lp]'
-    url: [ 'https://www.nexusmods.com/fallout4/mods/40553/' ]
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/40553/'
+        name: 'Slocum Joe Corporate HQ Reception Ceiling Fixed'
     group: *fixesGroup
 
   - name: 'Perk Magazine Material Fix.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1774,12 +1774,24 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/40513/'
         name: 'Nuka-World - Fixes the East Entrance to Nuka-Town USA near Fizztop Mountain'
     group: *fixesGroup
+  - name: 'MTM-GardenTerraceCeilingFixedByMonorail\.es[lp]'
+    msg:
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'Previsibines Repair Pack' ]
+        condition: 'active("PPF.esm")'
 
   - name: '(MTM-SlocumJoeCorporateHQReceptionCeilingFixed|MTM-FensParkviewApartmentWallFixed)\.es[lp]'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/40553/'
         name: 'Slocum Joe Corporate HQ Reception Ceiling Fixed'
     group: *fixesGroup
+  - name: 'MTM-SlocumJoeCorporateHQReceptionCeilingFixed\.es[lp]'
+    msg: [ *alreadyInUFO4P ]
+  - name: 'MTM-FensParkviewApartmentWallFixed\.es[lp]'
+    msg:
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'Previsibines Repair Pack' ]
+        condition: 'active("PPF.esm")'
 
   - name: 'Perk Magazine Material Fix.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/6906/' ]


### PR DESCRIPTION
Adds two similar fix mods by MrTroubleMaker.

* Add plugins
  * To 'Fixes' section.

* Add locations
  * [https://www.nexusmods.com/fallout4/mods/40513/](https://www.nexusmods.com/fallout4/mods/40513/)
  * [https://www.nexusmods.com/fallout4/mods/40553/](https://www.nexusmods.com/fallout4/mods/40553/)

* Assign 'Fixes' group
  * Adds new placed object references in worldspace cells, so can be loaded high in the load order.

* Add redundancy messages against UFO4P and PRP
  * UFO4P and PRP provide their own fixes to some of these plugins.