### PR TITLE
Add Worthwhile Caps Stashes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2528,6 +2528,16 @@ plugins:
       - Delev
       - Relev
 
+  - name: 'GKX Worthwhile Caps Stashes.esl'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/23464/'
+        name: 'Worthwhile Caps Stashes'
+    dirty:
+      - <<: *quickClean
+        crc: 0x02DECB7D
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 1
+  
   - name: 'MojaveImports.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/3793/'


### PR DESCRIPTION
* Add plugin to 'Gameplay' section.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/23464/](https://www.nexusmods.com/fallout4/mods/23464/)

* Leave in 'default' group
  * Edits only a single vanilla activator record for the cap stashes, otherwise adding new records. ESL plugin, so automatically sorts high in the load order, no adjustment needed.

* Add cleaning data (version 4.0)