### PR TITLE
Add Car Physics Death Bug Fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1652,6 +1652,24 @@ plugins:
       - <<: *alreadyInUFO4P
         condition: 'active("Unofficial Fallout 4 Patch.esp") and version("Unofficial Fallout 4 Patch.esp", "2.0.2", >=)'
 
+  - name: 'CarPhysicsDeathBugfix.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/46566'
+        name: 'Car Physics Death Bug Fix'
+    dirty:
+      - <<: *quickClean
+        crc: 0x3E061722
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 1
+      - <<: *quickClean
+        crc: 0x5DD022DA
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 1
+      - <<: *quickClean
+        crc: 0x245F236D
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 1
+
   - name: 'Combat Armor Weight Fix.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/11541/' ]
     group: *fixesGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1654,7 +1654,7 @@ plugins:
 
   - name: 'CarPhysicsDeathBugfix.esp'
     url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/46566'
+      - link: 'https://www.nexusmods.com/fallout4/mods/46566/'
         name: 'Car Physics Death Bug Fix'
     dirty:
       - <<: *quickClean


### PR DESCRIPTION
* Add plugin
  * To 'Fixes' section

* Add location
  * [https://www.nexusmods.com/fallout4/mods/46566/](https://www.nexusmods.com/fallout4/mods/46566/)

* Leave in 'default' group
  * Modifies a single game setting.

* Add cleaning data
  * All versions contain 1 ITM.