### PR TITLE
Add Boston Library Settlement

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3680,6 +3680,29 @@ plugins:
         itm: 64
         udr: 11
 
+  - name: 'BostonLibrarySettlement(PRP|Robots|SS2)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/68293/'
+        name: 'Boston Public Library Settlement'
+    group: *preVisCombinedGroup
+    after:
+      - 'PRP.esp'
+  - name: 'BostonLibrarySettlement.esp'
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Previsibines Repair Pack' ]
+        condition: 'active("PRP.esp") and not active("BostonLibrarySettlementPRP.esp")'
+      - <<: *patchProvided
+        subs: [ 'Automatron' ]
+        condition: 'active("DLCRobot.esm") and not active("BostonLibrarySettlementRobots.esp")'
+      - <<: *patchProvided
+        subs: [ 'Sim Settlements 2 - Chapter 2' ]
+        condition: 'active("SS2_XPAC_Chapter2.esm") and not active("BostonLibrarySettlementSS2.esp")'
+  - name: 'LibraryExtras.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/68293/'
+        name: 'Boston Public Library Settlement'
+
   - name: 'Bunker Hill D(CnR_F-ESL|eep Clean ESL-F)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/65014/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3685,8 +3685,7 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/68293/'
         name: 'Boston Public Library Settlement'
     group: *preVisCombinedGroup
-    after:
-      - 'PRP.esp'
+    after: [ 'PRP.esp' ]
   - name: 'BostonLibrarySettlement.esp'
     msg:
       - <<: *patchProvided

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3689,11 +3689,11 @@ plugins:
   - name: 'BostonLibrarySettlement.esp'
     msg:
       - <<: *patchProvided
-        subs: [ 'Previsibines Repair Pack' ]
-        condition: 'active("PRP.esp") and not active("BostonLibrarySettlementPRP.esp")'
-      - <<: *patchProvided
         subs: [ 'Automatron' ]
         condition: 'active("DLCRobot.esm") and not active("BostonLibrarySettlementRobots.esp")'
+      - <<: *patchProvided
+        subs: [ 'Previsibines Repair Pack' ]
+        condition: 'active("PRP.esp") and not active("BostonLibrarySettlementPRP.esp")'
       - <<: *patchProvided
         subs: [ 'Sim Settlements 2 - Chapter 2' ]
         condition: 'active("SS2_XPAC_Chapter2.esm") and not active("BostonLibrarySettlementSS2.esp")'


### PR DESCRIPTION
* Add plugins
  * To 'Locations - Overhauls' section
  * Turns the Boston Public Library into a settlement. Includes previsbines.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/68293](https://www.nexusmods.com/fallout4/mods/68293)

* Assign 'preVisCombinedGroup' group
  * Includes its own previsbines. Assigning this group allows it to sort after most incompatible plugins.

* Load after
  * PRP.esp

* Add 'Patch Provided' messages for
  * Previsbines Repair Pack
  * Automatron
  * Sim Settlements 2 Chapter 2

This info is for latest version 1.1.6 main file.

Please note that the LibraryExtras.esp v1.0 optional file contains all new records and is standalone, so it should be left in the default group.

