### PR TITLE
Add We Can Live In - Natick Substation

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3988,6 +3988,9 @@ plugins:
     group: *frostGroup
   - name: 'WCLI_NatickSubstation.esp'
     msg:
+      - <<: *compatIssuesWithX
+        subs: [ 'Natick Power Substation Player Settlement' ]
+        condition: 'active("123_settlement.esp")'
       - <<: *patchProvided
         subs: [ 'A Forest' ]
         condition: 'active("A Forest.esp") and not active("WCLINS_AF_Patch.esp")'
@@ -4021,9 +4024,6 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Waushakum Pond Settlement' ]
         condition: 'active("PondSettlement.esp") and not active("WCLINS_(WPS|SNWS_WPS)_Patch.esp")'
-      - <<: *compatIssuesWithX
-        subs: [ 'Natick Power Substation Player Settlement' ]
-        condition: 'active("123_settlement.esp")'
 
 ###### Locations - Player Homes ######
   - name: 'AlootHomePlate.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3981,6 +3981,47 @@ plugins:
       - 'BostonFPSFixAIO.esp'
       - 'PRP.esp'
 
+  - name: 'WCLI(_NatickSubstation|NS_.*)\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/64755/'
+        name: 'We Can Live In - Natick Substation'
+    group: *frostGroup
+  - name: 'WCLI_NatickSubstation.esp'
+    msg:
+      - <<: *patchProvided
+        subs: [ 'A Forest' ]
+        condition: 'active("A Forest.esp") and not active("WCLINS_AF_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Commonwealth Reclamation Project: Overgrowth' ]
+        condition: 'active("CRP1.esp") and not active("WCLINS_CRPO_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'David Hunter - A Brotherhood Story' ]
+        condition: 'active("BoSStory.esp") and not active("WCLINS_DHBOSS_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Desperados Overhaul' ]
+        condition: 'active("Desperados Overhaul.esp") and not active("WCLINS_DO_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Forsythia Replacer - Fungal Commonwealth LITE' ]
+        condition: 'active("Forsythia Replacer.esp") and not active("WCLINS_FR(NR)?_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'FROST Cell Fixes' ]
+        condition: 'active("FCF_Previsibines.esp") and not active("WCLINS_FROST_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Galac Tac Retribution' ]
+        condition: 'active("Galac-TactREDUX.esp") and not active("WCLINS_GTR_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Maxwell''s World' ]
+        condition: 'active("MaxwellsWorl.esp") and not active("WCLINS_MW_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Natick Warehouse Settlement' ]
+        condition: 'active("SKKNatickWarehouseSettlement.esp") and file("SKKNatickWarehouseSettlement - Main.BA2") and not active("WCLINS_(MW|SNWS_WPS)_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Previsibines Repair Pack' ]
+        condition: 'active("PRP.esp") and not active("WCLINS_PRP_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Waushakum Pond Settlement' ]
+        condition: 'active("PondSettlement.esp") and not active("WCLINS_(WPS|SNWS_WPS)_Patch.esp")'
+
 ###### Locations - Player Homes ######
   - name: 'AlootHomePlate.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4021,6 +4021,9 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Waushakum Pond Settlement' ]
         condition: 'active("PondSettlement.esp") and not active("WCLINS_(WPS|SNWS_WPS)_Patch.esp")'
+      - <<: *compatIssuesWithX
+        subs: [ 'Natick Power Substation Player Settlement' ]
+        condition: 'active("123_settlement.esp")'
 
 ###### Locations - Player Homes ######
   - name: 'AlootHomePlate.esp'


### PR DESCRIPTION
* Add plugins
  * To 'Locations - Overhauls' section
  * Turns Natick Substation into a settlement.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/64755/](https://www.nexusmods.com/fallout4/mods/64755/)

* Assign 'frostGroup' group
  * Includes its own previsbines and contains an optional patch that needs to load below FROST which loads in the 'frostGroup' group. Assigning this group allows it to sort after most incompatible plugins.

* Add 'Patch Provided" messages for
  * A Forest
  * Commonwealth Reclamation Project: Overgrowth
  * David Hunter - A Brotherhood Story
  * Desperados Overhaul
  * Forsythia Replacer - Fungal Commonwealth LITE
  * FROST Cell Fixes
  * Galac Tac Retribution
  * Maxwell's World
  * Natick Warehouse Settlement (using presence of the ba2 archive to detect the 'Build Version 006' version of the mod that requires the patch)
  * Previsibines Repair Pack
  * Waushakum Pond Settlement

* Add 'compatibility issues' message for
  * Natick Power Substation Player Settlement