### PR TITLE
Add Wetness Shader Fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2205,7 +2205,7 @@ plugins:
 
   - name: 'Wetness Shader Fix.esp'
     url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/23389'
+      - link: 'https://www.nexusmods.com/fallout4/mods/23389/'
         name: 'Wetness Shader Fix'
     group: *fixesGroup
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2203,6 +2203,12 @@ plugins:
         subs: [ 'Previsibines Repair Pack v0.57+' ]
         condition: 'active("PPF.esm")'
 
+  - name: 'Wetness Shader Fix.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/23389'
+        name: 'Wetness Shader Fix'
+    group: *fixesGroup
+
 ###### AudioVisual - Models & Textures ######
   - name: 'FO4ParticlePatch.esp'
     url:


### PR DESCRIPTION
* Add plugin
  * To 'AudioVisual - Fixes' section
  * This fixes the exaggerated shine of specific objects while it's raining. 

* Add location
  * [https://www.nexusmods.com/fallout4/mods/23389/](https://www.nexusmods.com/fallout4/mods/23389/)

* Assign 'Fixes' group
  * Plugin is a dummy esp to load material and specular texture assets inside archives.