### PR TITLE
Add Enhanced Vanilla Armor and Clothing

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2204,6 +2204,16 @@ plugins:
         condition: 'active("PPF.esm")'
 
 ###### AudioVisual - Models & Textures ######
+  - name: 'Enhanced Vanilla Armor and Clothing.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/72546/'
+        name: 'Enhanced Vanilla Armor and Clothing'
+    group: *texturesGroup
+    msg:
+      - <<: *requiresX
+        subs: [ '[RobCo Patcher](https://www.nexusmods.com/fallout4/mods/69798/)' ]
+        condition: 'not file("F4SE/Plugins/RobCo_Patcher.dll")'
+
   - name: 'FO4ParticlePatch.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/68599/'


### PR DESCRIPTION
* Add plugin
  * To 'AudioVisual - Models & Textures' section
  * Enhanced Vanilla Clothing and Armor (EVAC) is a complete overhaul of the appearance of armor and clothing.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/72546/]( https://www.nexusmods.com/fallout4/mods/72546/)

* Assign 'Texture Overhauls' group
  * Should load high in the load order. Record conflicts are unlikely.

* Add 'Requires' message
  * If [RobCo Patcher](https://www.nexusmods.com/fallout4/mods/69798/) is not installed.