### PR TITLE
Add Far Harbor Pine Branches 4K

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2211,6 +2211,12 @@ plugins:
         subs: [ '[RobCo Patcher](https://www.nexusmods.com/fallout4/mods/69798/)' ]
         condition: 'not file("F4SE/Plugins/RobCo_Patcher.dll")'
 
+  - name: 'Far Harbor Pine branches 4K.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/38147/'
+        name: 'Far Harbor Pine Branches 4K'
+    group: *texturesGroup
+
   - name: 'FO4ParticlePatch.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/68599/'


### PR DESCRIPTION
* Add plugin
  * To 'AudioVisual - Models & Textures' section
  * Texture and material fix for all 4 types of pine tree branches in Far Harbor.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/38147/](https://www.nexusmods.com/fallout4/mods/38147/)

* Assign 'Texture Overhauls' group
  * Plugin is a dummy esp to load material and texture assets inside archives.