### PR TITLE
Add Fixed Gobo Effects

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2223,6 +2223,12 @@ plugins:
         name: 'Far Harbor Pine Branches 4K'
     group: *texturesGroup
 
+  - name: 'Fixed Gobo Effects.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/27445/'
+        name: 'Fixed Gobo Effects'
+    group: *texturesGroup
+
   - name: 'FO4ParticlePatch.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/68599/'


### PR DESCRIPTION
* Add plugin
  * To 'AudioVisual - Models & Textures' section
  * Removes artifacts from gobo effect textures.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/27445/](https://www.nexusmods.com/fallout4/mods/27445/)

* Assign 'Texture Overhauls' group
  * Plugin is a dummy espfe to load texture assets inside included ba2 archive.