### PR TITLE
Add Immersive Generic Dialogues

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3184,6 +3184,17 @@ plugins:
       - crc: 0xDEF7E886
         util: 'FO4Edit v4.0.3h (Hotfix 1)'
 
+  - name: 'ImmersiveGenericDialogues.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/14108/'
+        name: 'Immersive Generic Dialogues'
+    group: *underridesGroup
+    dirty:
+      - <<: *quickClean
+        crc: 0x84725D54
+        util: '[FO4Edit v4.0.4](https://www.nexusmods.com/fallout4/mods/2737)'
+        itm: 3
+
   - name: 'NickValentineRomance.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/13717/' ]
     after:


### PR DESCRIPTION
* Add plugin
  * To 'Gameplay - NPC Behaviour & Dialogue' section
  * Adjusts generic dialogues to be more reflective of your reputation.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/14108/](https://www.nexusmods.com/fallout4/mods/14108/)

* Assign 'Underrides' group
  * Makes some placed NPCs in some interior and worldspace cells persistent. Modifies nested dialogue records.

* Add cleaning data
  * Version 1.03c English.