### PR TITLE
Assign group to Settler and Companion Dialogue Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3216,6 +3216,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/41785/'
         name: 'Settler and Companion Dialogue Overhaul'
+    group: *underridesGroup
     after:
       - 'FlirtyCommonwealth.esp'
       - 'FlirtyCommonwealthFemale.esp'


### PR DESCRIPTION
* Assign 'Underrides' group
  * Adds placed objects in interior and worldspace cells. Modifies nested dialogue records.