### PR TITLE
Add Lightweight Lighting

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2492,6 +2492,13 @@ plugins:
       - crc: 0x1DA07EEF
         util: 'FO4Edit v4.0.3'
 
+  - name: 'Lightweight Lighting( - Interiors Only)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/57680/'
+        name: 'Lightweight Lighting - A Weather and Interior Lighting Overhaul'
+    group: *lowPriorityGroup
+    after: [ 'Clarity.esp' ]
+
   - name: 'Pip-Boy Flashlight.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/10840/' ]
     after:


### PR DESCRIPTION
* Add plugins
  * To 'AudioVisual - Weather & Lighting' section
  * Lightweight lighting aims to be an all in one simple Vanilla + Lighting overhaul, all while being as compatible as can be with no cell edits.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/57680/](https://www.nexusmods.com/fallout4/mods/57680/)

* Assign 'Low Priority Overrides' group
  * Edits lighting and weather related records, which are all rule-of-one conflicts.

* Load after
  * Clarity.esp