### PR TITLE
Assign group to Pip-Boy Flashlight

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2494,6 +2494,7 @@ plugins:
 
   - name: 'Pip-Boy Flashlight.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/10840/' ]
+    group: *frostGroup
     after:
       - 'Clarity.esp'
       - 'EnhancedLightsandFX.esp'


### PR DESCRIPTION
* Assign 'FROST Survival Simulator' group
  * Needs to override FROST.esp, so it needs to be at least this low in the group list. Edits rule-of-one records.