### PR TITLE
Add Vault Door Announce Warning

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1849,6 +1849,12 @@ plugins:
         subs: [ 'Previsibines Repair Pack' ]
         condition: 'active("PPF.esm")'
 
+  - name: 'MTM-VaultAnnounceWarning.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/40266/'
+        name: 'Vault Door Announce Warning for Vaults 81, 88, 114, and 118'
+    group: *fixesGroup
+
   - name: 'Perk Magazine Material Fix.esp'
     url: [ 'https://www.nexusmods.com/fallout4/mods/6906/' ]
     group: *fixesGroup


### PR DESCRIPTION
* Add plugin
  * To 'Fixes' section
  * Adds a vault door announce warning and klaxon siren to Vaults 81, 88, 114, and 118.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/40266/](https://www.nexusmods.com/fallout4/mods/40266/)

* Assign 'Fixes' group
  * Modifies placed object references in interior cells.