### PR TITLE
Add Far Object LOD Improvement Project

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2232,7 +2232,7 @@ plugins:
     after: [ 'FO4LODGen.esp' ]
   - name: 'FOLIP - Before Generation.esp'
     group: *lowPriorityGroup
-    after: [ 'Workshop Rearranged.esp' ]
+    after: [ 'WorkshopRearranged.esp' ]
     msg: [ *disableAfterGeneratingLODwithxLODGen ]
 
   - name: 'Wetness Shader Fix.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2223,6 +2223,18 @@ plugins:
         subs: [ 'Optimized Vanilla Tree LODs' ]
         condition: 'active("Optimized Vanilla Tree LODs.esp")'
 
+  - name: 'FOLIP - (New LODs|Before|After)( Generation)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/61884/'
+        name: 'Far Object LOD Improvement Project'
+  - name: 'FOLIP - (New LODs|After Generation)\.esp'
+    group: *fixesGroup
+    after: [ 'FO4LODGen.esp' ]
+  - name: 'FOLIP - Before Generation.esp'
+    group: *lowPriorityGroup
+    after: [ 'Workshop Rearranged.esp' ]
+    msg: [ *disableAfterGeneratingLODwithxLODGen ]
+
   - name: 'Wetness Shader Fix.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/23389/'


### PR DESCRIPTION
* Add plugins
  * To 'AudioVisual - Fixes' section
  * Adds missing LODs for objects that don't currently have them.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/61884/](https://www.nexusmods.com/fallout4/mods/61884/)

* For 'FOLIP - New LODs.esp' and 'FOLIP - After Generation.esp'
  * Assign 'Fixes' group
    * Edits base static and material records. Modifies persistent worldspace placed object records.
  * Load After
    * FO4LODGen.esp

* For 'FOLIP - Before Generation.esp'
  * Assign 'Low Priority Overrides' group
    * This plugin is only to be used when generating LOD and should override any conflicting mods in order for the LOD models to be used. After generation, it should be removed, in that way removing any record conflicts.
  * Load After
    * WorkshopRearranged.esp
  * Add message
    * Noting that the plugin may be disabled after generating LOD with xLODGen.
