### PR TITLE
Add Vault 88 Essentials

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3125,6 +3125,15 @@ plugins:
         subs: [ 'Homemaker v1.50+' ]
         condition: 'version("Homemaker.esm", "1.50", >=)'
 
+  - name: 'Vault88 - Essentials.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/52121/'
+        name: 'Vault 88 Essentials'
+    group: *lowPriorityGroup
+    after:
+      - 'Clarity.esp'
+      - 'WorkshopRearranged.esp'
+
   - name: 'Vault-Tec Workshop Overhaul Redux.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/43643/'


### PR DESCRIPTION
* Add plugin
  * To 'Gameplay - Crafting, Harvesting & Scrapping' section
  * Combination, improvement and bug fixing for several popular Vault 88 Kit mods plus a small set of additions.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/52121/](https://www.nexusmods.com/fallout4/mods/52121/)

* Assign 'Low Priority Overrides' group
  * Rule-of-one record conflicts.

* Load after
  * Clarity.esp
  * WorkshopRearranged.esp