### PR TITLE
Update Covenant - Disable the dead caravan from Stockton

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1719,6 +1719,7 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/43961/'
         name: 'Covenant - Disable the dead caravan from Stockton'
     group: *fixesGroup
+    msg: [ *alreadyInUFO4P ]
   - name: 'DisabletheCaravan.esl'
     dirty:
       - <<: *quickClean


### PR DESCRIPTION
* Add message
  * Already in Unofficial Fallout 4 Patch (Cleaned up in UFO4P_MS17Cleanup [QUST:07009FE7])