### PR TITLE
Add Diamond City Billboards

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -279,6 +279,14 @@ common:
     condition: 'active("BLD - Merged - WSE Edition.esp")'
 
   # &alreadyInOrFixedByX
+  - &alreadyInOrFixedByFATEFixes
+    <<: *alreadyInOrFixedByX
+    subs: [ 'FATE Core - Fixes' ]
+    condition: 'active("FATE Core - Fixes.esl")'
+  - &alreadyInOrFixedByFATETweaks
+    <<: *alreadyInOrFixedByX
+    subs: [ 'FATE Core - Tweaks' ]
+    condition: 'active("FATE Core - Tweaks.esp")'
   - &alreadyInOrFixedByFO4
     <<: *alreadyInOrFixedByX
     subs: [ 'Fallout 4' ]
@@ -1713,6 +1721,13 @@ plugins:
     url: [ 'https://www.nexusmods.com/fallout4/mods/10892/' ]
     group: *fixesGroup
     msg: [ *alreadyInUFO4P ]
+
+  - name: 'DiamondCityBillboards.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/71990/'
+        name: 'Diamond City Billboards'
+    group: *fixesGroup
+    msg: [ *alreadyInOrFixedByFATETweaks ]
 
   - name: 'DisabletheCaravan\.es[lp]'
     url:


### PR DESCRIPTION
* Add plugin
  * To 'Fixes' section
  * Adds billboards from inside Diamond City to the exterior of Diamond City.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/71990/](https://www.nexusmods.com/fallout4/mods/71990/)

* Assign 'Fixes' group
  * Adds new placed object records in persistent worldspace cell.

* Add message anchors for [FATE](https://www.nexusmods.com/fallout4/mods/72679)
  * For mods in or fixed by 'FATE Core - Fixes'
  * For mods in or fixed by 'FATE Core - Tweaks'

* Add message
  * Included in 'FATE Core - Tweaks' 