### PR TITLE
Add Step Fallout 4 Guide patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4394,6 +4394,10 @@ plugins:
       - crc: 0xF4214BB4
         util: 'FO4Edit v4.0.4b'
 
+  - name: 'Step Patch - (Conflict Resolution|Lighting and Weather)\.esp'
+    url: ['https://www.nexusmods.com/fallout4/mods/74193/']
+    group: *lateChangesGroup
+
 ###### FROST Survival Simulator ######
   - name: 'FROST.esp'
     url:


### PR DESCRIPTION
* Add plugins
  * To '3rd Party Patches' section.
  * Conflict resolution patches for use with the Step Fallout 4 guide.

* Add location
  * [https://www.nexusmods.com/fallout4/mods/74193/]( https://www.nexusmods.com/fallout4/mods/74193/)

* Assign 'Late Fixes & Changes group
  * Designed to load after all mods in the Step guide right before any Dynamic Patches.