### PR TITLE
Remove clean data: DLCworkshop02.esm

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -549,9 +549,6 @@ plugins:
       - 'DLCRobot.esm'
       - 'DLCworkshop01.esm'
       - 'DLCCoast.esm'
-    clean:
-      - crc: 0x83ABC821
-        util: 'FO4Edit v4.1.5 EXPERIMENTAL'
   - name: 'DLCworkshop03.esm'
     group: *dlcGroup
     after:


### PR DESCRIPTION
Remove it since we don't feature the clean message for the other official plugins as well.

Ref: https://github.com/loot/fallout4/pull/596