### PR TITLE
Add warning for performance issues in FO4 Next Gen - NPC_ records

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -472,6 +472,13 @@ globals:
       - 'Fallout 4'
     condition: 'file("F4SE/Plugins/place.dll") and file("../f4se_loader.exe") and readable("../Fallout4.exe") and ((version("F4SE/Plugins/place.dll", "1.18.0.1163", ==) and version("../Fallout4.exe", "1.10.163.0", !=)) or (version("F4SE/Plugins/place.dll", "1.18.0.1163", <) and version("../Fallout4.exe", "1.10.163.0", ==)))'
 
+# Temporary warning: Performance Issues in FO4 Next Gen
+  - type: warn
+    content:
+      - lang: en
+        text: 'Fallout 4 Next Gen (version 1.10.984.0) has been found to experience performance issues such as stuttering and freezing in the presence of any mods overriding **NPC_** records. An official patch from Bethesda will need to address this issue.'
+    condition: 'file("../Fallout4.exe") and readable("../Fallout4.exe") and version("../Fallout4.exe", "1.10.984.0", ==)'
+
 groups:
   - name: &dlcGroup DLC
 


### PR DESCRIPTION
See [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1241134845443178516) for our discussion, where also test plugins have been provided.

In short, it appears that Fallout 4 Next Gen is experiencing performance issues in the presence of mods overriding `NPC_` records, which should be fixed through an official patch by Bethesda. To help mitigate any further confusion, at least in LOOTs user base, add a global message to the masterlist (at least for the time being).

<img width="896" height="876" alt="image" src="https://github.com/user-attachments/assets/4191b04f-52c8-4dac-80fa-5c90f19a6fc0" />

[RaiderTest_Plugins.zip](https://github.com/user-attachments/files/25446597/RaiderTest_Plugins.zip)
