### PR TITLE
Add Chameleon related mod rules

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7783,7 +7783,7 @@ plugins:
   - name: 'Chameleon No Sound.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886'
-        msg:
+    msg:
       - <<: *alreadyInOrFixedByX
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("AltChameleonVisuals.esp")'
@@ -7791,7 +7791,7 @@ plugins:
   - name: 'Chameleon No Sound.esp'
     url:
       - link: 'hhttps://www.nexusmods.com/fallout4/mods/1886'
-        msg:
+    msg:
       - <<: *alreadyInOrFixedByX
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("NoChameleonFlash.esp")'
@@ -7799,7 +7799,7 @@ plugins:
   - name: 'NoChameleonFlash.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886'
-        msg:
+    msg:
       - <<: *alreadyInX
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("AltChameleonVisuals.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7786,15 +7786,7 @@ plugins:
     msg:
       - <<: *alreadyInOrFixedByX
         subs: [ 'Alternative Chameleon Visuals' ]
-        condition: 'active("AltChameleonVisuals.esp")'
-        
-  - name: 'Chameleon No Sound.esp'
-    url:
-      - link: 'hhttps://www.nexusmods.com/fallout4/mods/1886'
-    msg:
-      - <<: *alreadyInOrFixedByX
-        subs: [ 'Alternative Chameleon Visuals' ]
-        condition: 'active("NoChameleonFlash.esp")'
+        condition: 'active("AltChameleonVisuals.esp") or active("NoChameleonFlash.esp")'
         
   - name: 'NoChameleonFlash.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7788,7 +7788,6 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("AltChameleonVisuals.esp") or active("NoChameleonFlash.esp")'
-        
   - name: '(Alt|No)Chameleon(Flash|Visuals)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7779,3 +7779,15 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/68889/'
         name: 'Extra Icons for FIS'
     after: [ 'FIS-Naming-Weap-Armo-EN.esp' ]
+
+  - name: 'AltChameleonVisuals.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/1886'
+        name: 'Alternative Chameleon Visuals'
+    after: [ 'Chameleon No Sound.esp' ]
+
+  - name: 'NoChameleonFlash.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/1886'
+        name: 'Alternative Chameleon Visuals'
+    after: [ 'Chameleon No Sound.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7789,7 +7789,7 @@ plugins:
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("AltChameleonVisuals.esp") or active("NoChameleonFlash.esp")'
         
-  - name: 'NoChameleonFlash.esp'
+  - name: '(Alt|No)Chameleon(Flash|Visuals)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886/'
         name: 'Alternative Chameleon Visuals'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7794,6 +7794,6 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886/'
         name: 'Alternative Chameleon Visuals'
     msg:
-      - <<: *alreadyInX
-        subs: [ 'Alternative Chameleon Visuals' ]
-        condition: 'active("AltChameleonVisuals.esp")'
+      - <<: *useOnlyOneX
+        subs: [ 'Alternative Chameleon Visuals ESP' ]
+        condition: 'many("(Alt|No)Chameleon(Flash|Visuals)\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7782,7 +7782,8 @@ plugins:
 
   - name: 'Chameleon No Sound.esp'
     url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/1886'
+      - link: 'https://www.nexusmods.com/fallout4/mods/26648/'
+        name: 'No Sound Chameleon cloak'
     msg:
       - <<: *alreadyInOrFixedByX
         subs: [ 'Alternative Chameleon Visuals' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7780,14 +7780,26 @@ plugins:
         name: 'Extra Icons for FIS'
     after: [ 'FIS-Naming-Weap-Armo-EN.esp' ]
 
-  - name: 'AltChameleonVisuals.esp'
+  - name: 'Chameleon No Sound.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886'
-        name: 'Alternative Chameleon Visuals'
-    after: [ 'Chameleon No Sound.esp' ]
-
+        msg:
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'Alternative Chameleon Visuals' ]
+        condition: 'active("AltChameleonVisuals.esp")'
+        
+  - name: 'Chameleon No Sound.esp'
+    url:
+      - link: 'hhttps://www.nexusmods.com/fallout4/mods/1886'
+        msg:
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'Alternative Chameleon Visuals' ]
+        condition: 'active("NoChameleonFlash.esp")'
+        
   - name: 'NoChameleonFlash.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/1886'
-        name: 'Alternative Chameleon Visuals'
-    after: [ 'Chameleon No Sound.esp' ]
+        msg:
+      - <<: *alreadyInX
+        subs: [ 'Alternative Chameleon Visuals' ]
+        condition: 'active("AltChameleonVisuals.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7785,7 +7785,7 @@ plugins:
       - link: 'https://www.nexusmods.com/fallout4/mods/26648/'
         name: 'No Sound Chameleon cloak'
     msg:
-      - <<: *alreadyInOrFixedByX
+      - <<: *alreadyInX
         subs: [ 'Alternative Chameleon Visuals' ]
         condition: 'active("AltChameleonVisuals.esp") or active("NoChameleonFlash.esp")'
         

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7791,7 +7791,8 @@ plugins:
         
   - name: 'NoChameleonFlash.esp'
     url:
-      - link: 'https://www.nexusmods.com/fallout4/mods/1886'
+      - link: 'https://www.nexusmods.com/fallout4/mods/1886/'
+        name: 'Alternative Chameleon Visuals'
     msg:
       - <<: *alreadyInX
         subs: [ 'Alternative Chameleon Visuals' ]


### PR DESCRIPTION
No Sound Chameleon Cloak
( https://www.nexusmods.com/fallout4/mods/26648 )

overrides some entries from

Alternative Chameleon Visuals
( https://www.nexusmods.com/fallout4/mods/1886 )

if not sorted correctly and makes the screen flash effect appear again.