### PR TITLE
Add group for Water Overhauls

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -580,9 +580,13 @@ groups:
   - name: &latePatchesGroup Late Patches
     after: [ *lateLoadersGroup ]
 
+  - name: &waterOverhaulsGroup Water Overhauls
+    description: 'A group for mods that change water textures and settings.'
+    after: [ *latePatchesGroup ]
+
   - name: &worldSettingsGroup Worldspace Settings
     description: 'A group for modules that need to be loaded late to preserve worldspace settings.'
-    after: [ *latePatchesGroup ]
+    after: [ *waterOverhaulsGroup ]
 
   - name: &conflictResPatchGroup Conflict Resolution Patches
     description: 'A group for patches that resolve conflicts.'


### PR DESCRIPTION
Adding to split up the worldspace group and move WET from low priority group, which is getting crowded.

#600 