### PR TITLE
Update We Can Live In - Natick Substation

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4433,11 +4433,10 @@ plugins:
       - 'BostonFPSFixAIO.esp'
       - 'PRP.esp'
 
-  - name: 'WCLI(_NatickSubstation|NS_.*)\.esp'
+  - name: 'WCLI_NatickSubstation.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/64755/'
         name: 'We Can Live In - Natick Substation'
-  - name: 'WCLI_NatickSubstation.esp'
     after:
       - 'Another Pine Forest Mod.esp'
     msg:
@@ -4480,7 +4479,10 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Waushakum Pond Settlement' ]
         condition: 'active("PondSettlement.esp") and (not active("WCLINS_Previs.esp") or (not checksum("WCLINS_Previs.esp", 0BEADEC1) and not checksum("WCLINS_Previs.esp", 26F48A9B) and not checksum("WCLINS_Previs.esp", 8004C20D)))'
-
+  - name: 'WCLINS_((AF|DHBOSS|FR|FRNR|MW)_Patch|Previs)\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/fallout4/mods/64755/'
+        name: 'We Can Live In - Natick Substation'
   - name: 'WCLINS_Previs.esp'
     after:
       - 'WCLINS_AF_Patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4437,7 +4437,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/64755/'
         name: 'We Can Live In - Natick Substation'
-    group: *mediumPriorityGroup
   - name: 'WCLI_NatickSubstation.esp'
     after:
       - 'Another Pine Forest Mod.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4484,6 +4484,9 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Waushakum Pond Settlement' ]
         condition: 'active("PondSettlement.esp") and (not active("WCLINS_Previs.esp") or (not checksum("WCLINS_Previs.esp", 0BEADEC1) and not checksum("WCLINS_Previs.esp", 26F48A9B) and not checksum("WCLINS_Previs.esp", 8004C20D)))'
+    clean:
+      - crc: 0x7FF4130D
+        util: 'FO4Edit v4.1.5k'
   - name: 'WCLINS_((AF|DHBOSS|FR|FRNR|MW)_Patch|Previs)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/64755/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4439,6 +4439,11 @@ plugins:
         name: 'We Can Live In - Natick Substation'
     after:
       - 'Another Pine Forest Mod.esp'
+      # The rules below are not strictly required, added to match expected order.
+      - '3DNPC_FO4.esp'
+      - 'BTInteriors_Project.esp'
+      - 'FCF_Main.esp'
+      - 'prp.esp'
     msg:
       - <<: *compatIssuesWithX
         subs: [ 'Natick Power Substation Player Settlement' ]


### PR DESCRIPTION
Removing from group,as it's position can be quite dynamic and a fixed position does not suit it.
Patches being grouped with regex can cause sorting errors if patched mod is grouped later.
In this case there are sorting errors with Frost installed.

#606