### PR TITLE
Update Who's The General - Minutemen Quest Cleanup

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4300,14 +4300,48 @@ plugins:
       - crc: 0xAD49CDCC
         util: 'FO4Edit v4.1.5k'
 
-  - name: 'WhoIsTheGeneral.esp'
+  - name: '(WhoIsTheGeneral|WTG( - |_)(CMRQL|CTI|KRIC|KCR|MRS|PGNRSQ|RQIC|RSFMQ|CMRQL - KRIC)( |_)Patch).esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/59019/'
         name: 'Who''s The General - Minutemen Quest Cleanup'
+  - name: 'WhoIsTheGeneral.esp'
     after: [ 'PiperCaitCurieDialogueOverhaul.esp' ]
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Configurable Minutemen Radiant Quest Limits And Fixes' ]
+        condition: 'active("CMRQL.esp") and not active("WTG - CMRQL Patch.esp") and not active("Keep Radiants In Commonwealth.esp")'
+      - <<: *patchProvided
+        subs: [ 'Conquer the Institute' ]
+        condition: 'active("Conquer the Institute.esp") and not active("WTG - CTI Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Keep Radiants in the Commonwealth' ]
+        condition: 'active("Keep Radiants In Commonwealth.esp") and not active("WTG - KRIC Patch.esp") and not active("CMRQL.esp")'
+      - <<: *patchProvided
+        subs: [ 'Keeper of the Commonwealth Radiants' ]
+        condition: 'active("Keeper of the Commonwealth Radiants.esp") and not active("WTG_KCR_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Minutemen (Radiant) Squads' ]
+        condition: 'active("MMSquads.esp") and not active("WTG - MRS Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Preston Garvey No Radiant Settlement Quests' ]
+        condition: 'active("PrestonNoRadiant.esp") and not active("WTG_PGNRSQ_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Radiant Questing in the Commonwealth' ]
+        condition: 'active("Radiant_Questing_in_the_Commonwealth.esp") and not active("WTG - RQIC Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Random Settlements for Minutemen Quests' ]
+        condition: 'active("Random Settlements For Minutemen Quests.esp.esp") and not active("WTG_RSFMQ_Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Configurable Minutemen Radiant Quest Limits And Fixes & Keep Radiants in the Commonwealth' ]
+        condition: 'active("CMRQL.esp") and active("Keep Radiants In Commonwealth.esp") and not active("WTG - CMRQL - KRIC Patch.esp")'
     clean:
-      - crc: 0x34DCB32F
-        util: 'FO4Edit v4.0.4b'
+      - crc: 0x191EDA88
+        util: 'FO4Edit v4.1.5f'
+  - name: 'WTG - (CMRQL|KRIC) Patch.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'Who''s the General - Merged Patch - CMRQL - KRIC' ]
+        condition: 'active("WTG - CMRQL - KRIC Patch.esp")'
 
 ###### Gameplay - Skills, Perks & Leveling ######
   - name: 'Freeze( - Vanilla Patch)?\.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4300,7 +4300,7 @@ plugins:
       - crc: 0xAD49CDCC
         util: 'FO4Edit v4.1.5k'
 
-  - name: '(WhoIsTheGeneral|WTG( - |_)(CMRQL|CTI|KRIC|KCR|MRS|PGNRSQ|RQIC|RSFMQ|CMRQL - KRIC)( |_)Patch)\.esp'
+  - name: '(WhoIsTheGeneral|WTG( - |_)(CMRQL( - KRIC)?|CTI|KCR|KRIC|MRS|PGNRSQ|RQIC|RSFMQ)( |_)Patch)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/59019/'
         name: 'Who''s The General - Minutemen Quest Cleanup'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4300,7 +4300,7 @@ plugins:
       - crc: 0xAD49CDCC
         util: 'FO4Edit v4.1.5k'
 
-  - name: '(WhoIsTheGeneral|WTG( - |_)(CMRQL|CTI|KRIC|KCR|MRS|PGNRSQ|RQIC|RSFMQ|CMRQL - KRIC)( |_)Patch).esp'
+  - name: '(WhoIsTheGeneral|WTG( - |_)(CMRQL|CTI|KRIC|KCR|MRS|PGNRSQ|RQIC|RSFMQ|CMRQL - KRIC)( |_)Patch)\.esp'
     url:
       - link: 'https://www.nexusmods.com/fallout4/mods/59019/'
         name: 'Who''s The General - Minutemen Quest Cleanup'
@@ -4337,7 +4337,7 @@ plugins:
     clean:
       - crc: 0x191EDA88
         util: 'FO4Edit v4.1.5f'
-  - name: 'WTG - (CMRQL|KRIC) Patch.esp'
+  - name: 'WTG - (CMRQL|KRIC) Patch\.esp'
     msg:
       - <<: *alreadyInX
         subs: [ 'Who''s the General - Merged Patch - CMRQL - KRIC' ]


### PR DESCRIPTION
\* Update cleaning data for main plugin
\- Version: 1.12

\* Add plugins
\- Regex plugin
\- CMRQL & KRIC patch regex plugin: WTG - CMRQL - KRIC Patch.esp

\* Move location from main plugin to regex plugin

\* Add messages to main plugin
\- &patchProvided: Configurable Minutemen Radiant Quest Limits And Fixes
\- &patchProvided: Conquer the Institute
\- &patchProvided: Keep Radiants in the Commonwealth
\- &patchProvided: Keeper of the Commonwealth Radiants
\- &patchProvided: Minutemen (Radiant) Squads
\- &patchProvided: Preston Garvey No Radiant Settlement Quests
\- &patchProvided: Radiant Questing in the Commonwealth
\- &patchProvided: Random Settlements for Minutemen Quests
\- &patchProvided: Configurable Minutemen Radiant Quest Limits And Fixes & Keep Radiants in the Commonwealth

\* Add message to CMRQL & KRIC patch regex plugin
\- &alreadyInX: If combined patch is active