### PR TITLE
Update Homemaker - Expanded Settlements

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6913,8 +6913,12 @@ plugins:
     msg:
       - <<: *obsolete
         condition: 'version("Homemaker.esm", "1.50", <)'
+      - <<: *patchUpdateAvailable
+        type: warn
+        subs: [ '[Homemaker 1.79.6 - Hotfix 6](https://www.nexusmods.com/fallout4/mods/1478/)' ]
+        condition: 'checksum("Homemaker.esm", 5730BA7B)'
     clean:
-      - crc: 0x23927824
+      - crc: 0x4AF4D5FC
         util: 'FO4Edit v4.1.5f'
 
   - name: 'SettlementKeywords.esm'


### PR DESCRIPTION
\* Update cleaning data for main plugin
\- Version: 1.79.6

\* Add message to main plugin
\- &patchUpdateAvailable: Prompts to install hotfix if 1.79.1 is installed