### PR TITLE
Remove temporary warning

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -543,13 +543,6 @@ globals:
       - 'Fallout 4'
     condition: 'file("F4SE/Plugins/place.dll") and file("../f4se_loader.exe") and readable("../Fallout4.exe") and ((version("F4SE/Plugins/place.dll", "1.18.0.1163", ==) and version("../Fallout4.exe", "1.10.163.0", !=)) or (version("F4SE/Plugins/place.dll", "1.18.0.1163", <) and version("../Fallout4.exe", "1.10.163.0", ==)))'
 
-# Temporary warning: Performance Issues in FO4 Next Gen
-  - type: warn
-    content:
-      - lang: en
-        text: 'Fallout 4 Next Gen (version 1.10.984.0) has been found to experience performance issues such as stuttering and freezing in the presence of any mods overriding **NPC_** records. An official patch from Bethesda will need to address this issue.'
-    condition: 'file("../Fallout4.exe") and readable("../Fallout4.exe") and version("../Fallout4.exe", "1.10.984.0", ==)'
-
 groups:
   - name: &dlcGroup DLC
 


### PR DESCRIPTION
See [this issue](https://github.com/loot/loot/issues/2149#issuecomment-3520627087) for more details.

Reverts [PR 611](https://github.com/loot/fallout4/pull/611).